### PR TITLE
Add simple tests for SDDS utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ The SDDS API provides functions for defining and manipulating SDDS datasets. Som
 
 For more details, refer to the **[SDDS API documentation](https://ops.aps.anl.gov/manuals/SDDSlib/html/files.html)**.
 
+## Tests
+Simple regression tests are provided for `sddscheck` and `sddsconvert`. After building the project run:
+```bash
+pytest -q
+```
+The tests require the binaries in `bin/Linux-x86_64` and use `SDDSlib/demo/example.sdds` as sample data.
+
+
 ## ChatGPT Assistant
 A custom **[ChatGPT SDDS C/C++ Language Assistant](https://chatgpt.com/g/g-67376bce92308190a01b7056cdd3d74a-sdds-c-c-language-assistant)** is available to help write new SDDS software.
 

--- a/tests/test_sdds_tools.py
+++ b/tests/test_sdds_tools.py
@@ -1,0 +1,26 @@
+import subprocess
+from pathlib import Path
+import pytest
+
+SDDSCHECK = Path("bin/Linux-x86_64/sddscheck")
+SDDSCONVERT = Path("bin/Linux-x86_64/sddsconvert")
+
+@pytest.mark.skipif(not SDDSCHECK.exists(), reason="sddscheck not built")
+def test_sddscheck_ok():
+    result = subprocess.run([str(SDDSCHECK), "SDDSlib/demo/example.sdds"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "ok"
+
+@pytest.mark.skipif(not (SDDSCHECK.exists() and SDDSCONVERT.exists()), reason="tools not built")
+def test_sddsconvert(tmp_path):
+    binary_file = tmp_path / "binary.sdds"
+    ascii_file = tmp_path / "ascii.sdds"
+
+    subprocess.run([str(SDDSCONVERT), "SDDSlib/demo/example.sdds", str(binary_file), "-binary"], check=True)
+    result = subprocess.run([str(SDDSCHECK), str(binary_file)], capture_output=True, text=True)
+    assert result.stdout.strip() == "ok"
+
+    subprocess.run([str(SDDSCONVERT), str(binary_file), str(ascii_file), "-ascii"], check=True)
+    result = subprocess.run([str(SDDSCHECK), str(ascii_file)], capture_output=True, text=True)
+    assert result.stdout.strip() == "ok"
+


### PR DESCRIPTION
## Summary
- add pytest-based test suite for `sddscheck` and `sddsconvert`
- document running tests in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae2e5ce08325bef538622f293d6a