### PR TITLE
Add regression tests for command options

### DIFF
--- a/tests/test_sdds_tools.py
+++ b/tests/test_sdds_tools.py
@@ -11,6 +11,13 @@ def test_sddscheck_ok():
     assert result.returncode == 0
     assert result.stdout.strip() == "ok"
 
+
+@pytest.mark.skipif(not SDDSCHECK.exists(), reason="sddscheck not built")
+def test_sddscheck_print_errors():
+    result = subprocess.run([str(SDDSCHECK), "SDDSlib/demo/example.sdds", "-printErrors"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "ok"
+
 @pytest.mark.skipif(not (SDDSCHECK.exists() and SDDSCONVERT.exists()), reason="tools not built")
 def test_sddsconvert(tmp_path):
     binary_file = tmp_path / "binary.sdds"
@@ -22,5 +29,45 @@ def test_sddsconvert(tmp_path):
 
     subprocess.run([str(SDDSCONVERT), str(binary_file), str(ascii_file), "-ascii"], check=True)
     result = subprocess.run([str(SDDSCHECK), str(ascii_file)], capture_output=True, text=True)
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.skipif(not (SDDSCHECK.exists() and SDDSCONVERT.exists()), reason="tools not built")
+@pytest.mark.parametrize(
+    "option",
+    [
+        ["-binary"],
+        ["-ascii"],
+        ["-delete=column,shortCol"],
+        ["-retain=column,shortCol"],
+        ["-rename=column,shortCol=shortCol2"],
+        ["-description=test,contents"],
+        ["-table=1"],
+        ["-editnames=column,*Col,*New"],
+        ["-linesperrow=1"],
+        ["-nowarnings"],
+        ["-recover"],
+        ["-pipe=output"],
+        ["-fromPage=1"],
+        ["-toPage=1"],
+        ["-acceptAllNames"],
+        ["-removePages=1"],
+        ["-keepPages=1"],
+        ["-rowlimit=1"],
+        ["-majorOrder=column"],
+        ["-convertUnits=column,doubleCol,m"],
+    ],
+)
+def test_sddsconvert_options(tmp_path, option):
+    output = tmp_path / "out.sdds"
+    cmd = [str(SDDSCONVERT), "SDDSlib/demo/example.sdds"]
+    if option[0].startswith("-pipe"):
+        cmd.append(option[0])
+        with output.open("wb") as f:
+            subprocess.run(cmd, stdout=f, check=True)
+    else:
+        cmd += [str(output)] + option
+        subprocess.run(cmd, check=True)
+    result = subprocess.run([str(SDDSCHECK), str(output)], capture_output=True, text=True)
     assert result.stdout.strip() == "ok"
 


### PR DESCRIPTION
## Summary
- expand test coverage to include `sddscheck -printErrors`
- parametrize `sddsconvert` tests to exercise all available command line options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bba4314c832596f50072729ab535