### PR TITLE
Update test output format

### DIFF
--- a/tests/test_sdds_tools.py
+++ b/tests/test_sdds_tools.py
@@ -4,12 +4,14 @@ from contextlib import nullcontext
 import pytest
 
 
-def run_prog(cmd, expected_stdout=None, *, capsys=None, **kwargs):
+def run_prog(cmd, expected_stdout=None, *, capsys=None, prefix=None, **kwargs):
     """Run a command while reporting its status."""
     program = Path(cmd[0]).name
+    message = prefix if prefix is not None else program
     out_context = capsys.disabled if capsys is not None else nullcontext
-    with out_context():
-        print(program, end="", flush=True)
+    if message:
+        with out_context():
+            print(message, end="", flush=True)
 
     # Ensure output is captured when validation is requested
     capture_needed = expected_stdout is not None and "stdout" not in kwargs and "capture_output" not in kwargs
@@ -40,7 +42,12 @@ def test_sddscheck_ok(capsys):
 
 @pytest.mark.skipif(not SDDSCHECK.exists(), reason="sddscheck not built")
 def test_sddscheck_print_errors(capsys):
-    run_prog([str(SDDSCHECK), "SDDSlib/demo/example.sdds", "-printErrors"], expected_stdout="ok", capsys=capsys)
+    print("Testing sddscheck options:")
+    run_prog([
+        str(SDDSCHECK),
+        "SDDSlib/demo/example.sdds",
+        "-printErrors",
+    ], expected_stdout="ok", capsys=capsys, prefix="  -printErrors")
 
 @pytest.mark.skipif(not (SDDSCHECK.exists() and SDDSCONVERT.exists()), reason="tools not built")
 def test_sddsconvert(tmp_path, capsys):
@@ -55,40 +62,39 @@ def test_sddsconvert(tmp_path, capsys):
 
 
 @pytest.mark.skipif(not (SDDSCHECK.exists() and SDDSCONVERT.exists()), reason="tools not built")
-@pytest.mark.parametrize(
-    "option",
-    [
-        ["-binary"],
-        ["-ascii"],
-        ["-delete=column,shortCol"],
-        ["-retain=column,shortCol"],
-        ["-rename=column,shortCol=shortCol2"],
-        ["-description=test,contents"],
-        ["-table=1"],
-        ["-editnames=column,*Col,*New"],
-        ["-linesperrow=1"],
-        ["-nowarnings"],
-        ["-recover"],
-        ["-pipe=output"],
-        ["-fromPage=1"],
-        ["-toPage=1"],
-        ["-acceptAllNames"],
-        ["-removePages=1"],
-        ["-keepPages=1"],
-        ["-rowlimit=1"],
-        ["-majorOrder=column"],
-        ["-convertUnits=column,doubleCol,m"],
-    ],
-)
-def test_sddsconvert_options(tmp_path, option, capsys):
-    output = tmp_path / "out.sdds"
-    cmd = [str(SDDSCONVERT), "SDDSlib/demo/example.sdds"]
-    if option[0].startswith("-pipe"):
-        cmd.append(option[0])
-        with output.open("wb") as f:
-            run_prog(cmd, stdout=f, capsys=capsys)
-    else:
-        cmd += [str(output)] + option
-        run_prog(cmd, capsys=capsys)
-    run_prog([str(SDDSCHECK), str(output)], expected_stdout="ok", capsys=capsys)
+def test_sddsconvert_options(tmp_path, capsys):
+    options = [
+        "-binary",
+        "-ascii",
+        "-delete=column,shortCol",
+        "-retain=column,shortCol",
+        "-rename=column,shortCol=shortCol2",
+        "-description=test,contents",
+        "-table=1",
+        "-editnames=column,*Col,*New",
+        "-linesperrow=1",
+        "-nowarnings",
+        "-recover",
+        "-pipe=output",
+        "-fromPage=1",
+        "-toPage=1",
+        "-acceptAllNames",
+        "-removePages=1",
+        "-keepPages=1",
+        "-rowlimit=1",
+        "-majorOrder=column",
+        "-convertUnits=column,doubleCol,m",
+    ]
+    print("Testing sddsconvert options:")
+    for opt in options:
+        output = tmp_path / "out.sdds"
+        cmd = [str(SDDSCONVERT), "SDDSlib/demo/example.sdds"]
+        if opt.startswith("-pipe"):
+            cmd.append(opt)
+            with output.open("wb") as f:
+                run_prog(cmd, stdout=f, capsys=capsys, prefix=f"  {opt}")
+        else:
+            cmd += [str(output), opt]
+            run_prog(cmd, capsys=capsys, prefix=f"  {opt}")
+        run_prog([str(SDDSCHECK), str(output)], expected_stdout="ok", prefix="")
 


### PR DESCRIPTION
## Summary
- expand `run_prog` helper to allow custom prefix
- show grouped option output in `test_sddscheck_print_errors`
- combine `test_sddsconvert_options` into a single loop with option output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841c6ecd4588325a2789bd50f2c598b