### PR TITLE
Fix compiler warnings in utility libraries

### DIFF
--- a/mdbcommon/scanargs.c
+++ b/mdbcommon/scanargs.c
@@ -317,7 +317,8 @@ void prompt_for_arguments(int *argc, char ***argv) {
   tfree(cmd_line_arg);
 
   do {
-    fgets(buffer, 1024, stdin);
+    if (!fgets(buffer, sizeof(buffer), stdin))
+      return;
     buffer[strlen(buffer) - 1] = 0;
     while ((ptr = get_token_tq(buffer, " ", " ", "\"", "\""))) {
       if (*ptr == '&')

--- a/mdblib/array.c
+++ b/mdblib/array.c
@@ -187,14 +187,15 @@ void *trealloc(void *old_ptr, uint64_t size_of_block) {
 
   if (!old_ptr)
     return (tmalloc(size_of_block));
-  if (!(ptr = realloc((void *)old_ptr, (uint64_t)(size_of_block)))) {
+  uint64_t oldaddr = (uint64_t)old_ptr;
+  if (!(ptr = realloc(old_ptr, (uint64_t)(size_of_block)))) {
     printf("error: memory reallocation failure--%"PRIu64" bytes requested.\n",
            size_of_block);
     printf("trealloc() has reallocated %"PRIu64" bytes previously\n", total_bytes);
     abort();
   }
   if (fp_trealloc) {
-    fprintf(fp_trealloc, "d:%"PRIx64"\na:%"PRIx64"  %"PRIu64"\n", (uint64_t)old_ptr,
+    fprintf(fp_trealloc, "d:%"PRIx64"\na:%"PRIx64"  %"PRIu64"\n", oldaddr,
             (uint64_t)ptr, size_of_block);
     fflush(fp_trealloc);
   }

--- a/mdblib/query.c
+++ b/mdblib/query.c
@@ -34,7 +34,8 @@ double query_double(char *prompt, double def) {
   static double val;
 
   printf("%s [%g]: ", prompt, def);
-  fgets(s, 99, stdin);
+  if (!fgets(s, sizeof(s), stdin))
+    return def;
   val = def;
   if (*s)
     sscanf(s, "%lf", &val);
@@ -56,7 +57,8 @@ float query_float(char *prompt, float def) {
   static float val;
 
   printf("%s [%g]: ", prompt, def);
-  fgets(s, 99, stdin);
+  if (!fgets(s, sizeof(s), stdin))
+    return def;
   val = def;
   if (*s)
     sscanf(s, "%f", &val);
@@ -78,7 +80,8 @@ long query_long(char *prompt, long def) {
   static long val;
 
   printf("%s [%ld]: ", prompt, def);
-  fgets(s, 99, stdin);
+  if (!fgets(s, sizeof(s), stdin))
+    return def;
   val = def;
   if (*s)
     sscanf(s, "%ld", &val);
@@ -100,7 +103,8 @@ int query_int(char *prompt, int def) {
   static int val;
 
   printf("%s [%d]: ", prompt, def);
-  fgets(s, 99, stdin);
+  if (!fgets(s, sizeof(s), stdin))
+    return def;
   val = def;
   if (*s)
     sscanf(s, "%d", &val);
@@ -122,7 +126,8 @@ short query_short(char *prompt, short def) {
   static short val;
 
   printf("%s [%d]: ", prompt, def);
-  fgets(s, 99, stdin);
+  if (!fgets(s, sizeof(s), stdin))
+    return def;
   val = def;
   if (*s)
     sscanf(s, "%hd", &val);

--- a/mdblib/replacefile.c
+++ b/mdblib/replacefile.c
@@ -52,7 +52,10 @@ long renameRobust(char *oldName, char *newName, unsigned long flags)
 #else
   sprintf(buffer, "cp %s %s", oldName, newName);
 #endif
-  system(buffer);
+  {
+    int ret = system(buffer);
+    (void)ret;
+  }
   if (!fexists(newName)) {
     fprintf(stderr, "unable to copy %s to %s\n", oldName, newName);
     return 1;

--- a/mdblib/unpack.c
+++ b/mdblib/unpack.c
@@ -118,7 +118,8 @@ FILE *UnpackFopen(char *filename, unsigned long mode, short *popenUsed, char **t
     tmpName = tmpname(NULL);
     strcat(command, "> /tmp/");
     strcat(command, tmpName);
-    system(command);
+    int ret = system(command);
+    (void)ret;
 
     sprintf(command, "/tmp/%s", tmpName);
     if (tmpFileUsed)


### PR DESCRIPTION
## Summary
- check `fgets` return values in `mdblib/query.c` and `mdbcommon/scanargs.c`
- silence `system` call warnings in `mdblib/replacefile.c` and `mdblib/unpack.c`
- prevent use-after-free warning in `mdblib/array.c`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f6319c708325979af20604432dfa