### PR TITLE
Fix levmar header warnings

### DIFF
--- a/levmar/lm.h
+++ b/levmar/lm.h
@@ -54,25 +54,25 @@ extern "C" {
   extern int dlevmar_der(
                          void (*func)(double *p, double *hx, int m, int n, void *adata),
                          void (*jacf)(double *p, double *j, int m, int n, void *adata),
-                         double *p, double *x, int m, int n, int itmax, double *opts,
-                         double *info, double *work, double *covar, void *adata);
+                         double *p, double *x, int m, int n, int itmax, double opts[4],
+                         double info[LM_INFO_SZ], double *work, double *covar, void *adata);
 
   extern int dlevmar_dif(
                          void (*func)(double *p, double *hx, int m, int n, void *adata),
-                         double *p, double *x, int m, int n, int itmax, double *opts,
-                         double *info, double *work, double *covar, void *adata);
+                         double *p, double *x, int m, int n, int itmax, double opts[5],
+                         double info[LM_INFO_SZ], double *work, double *covar, void *adata);
 
   /* box-constrained minimization */
   extern int dlevmar_bc_der(
                             void (*func)(double *p, double *hx, int m, int n, void *adata),
                             void (*jacf)(double *p, double *j, int m, int n, void *adata),  
                             double *p, double *x, int m, int n, double *lb, double *ub,
-                            int itmax, double *opts, double *info, double *work, double *covar, void *adata);
+                            int itmax, double opts[4], double info[LM_INFO_SZ], double *work, double *covar, void *adata);
 
   extern int dlevmar_bc_dif(
                             void (*func)(double *p, double *hx, int m, int n, void *adata),
                             double *p, double *x, int m, int n, double *lb, double *ub,
-                            int itmax, double *opts, double *info, double *work, double *covar, void *adata);
+                            int itmax, double opts[5], double info[LM_INFO_SZ], double *work, double *covar, void *adata);
 
 #ifdef HAVE_LAPACK
   /* linear equation constrained minimization */
@@ -80,12 +80,12 @@ extern "C" {
                              void (*func)(double *p, double *hx, int m, int n, void *adata),
                              void (*jacf)(double *p, double *j, int m, int n, void *adata),
                              double *p, double *x, int m, int n, double *A, double *b, int k,
-                             int itmax, double *opts, double *info, double *work, double *covar, void *adata);
+                             int itmax, double opts[4], double info[LM_INFO_SZ], double *work, double *covar, void *adata);
 
   extern int dlevmar_lec_dif(
                              void (*func)(double *p, double *hx, int m, int n, void *adata),
                              double *p, double *x, int m, int n, double *A, double *b, int k,
-                             int itmax, double *opts, double *info, double *work, double *covar, void *adata);
+                             int itmax, double opts[5], double info[LM_INFO_SZ], double *work, double *covar, void *adata);
 #endif /* HAVE_LAPACK */
 
 
@@ -94,25 +94,25 @@ extern "C" {
   extern int slevmar_der(
                          void (*func)(float *p, float *hx, int m, int n, void *adata),
                          void (*jacf)(float *p, float *j, int m, int n, void *adata),
-                         float *p, float *x, int m, int n, int itmax, float *opts,
-                         float *info, float *work, float *covar, void *adata);
+                         float *p, float *x, int m, int n, int itmax, float opts[4],
+                         float info[LM_INFO_SZ], float *work, float *covar, void *adata);
 
   extern int slevmar_dif(
                          void (*func)(float *p, float *hx, int m, int n, void *adata),
-                         float *p, float *x, int m, int n, int itmax, float *opts,
-                         float *info, float *work, float *covar, void *adata);
+                         float *p, float *x, int m, int n, int itmax, float opts[5],
+                         float info[LM_INFO_SZ], float *work, float *covar, void *adata);
 
   /* box-constrained minimization */
   extern int slevmar_bc_der(
                             void (*func)(float *p, float *hx, int m, int n, void *adata),
                             void (*jacf)(float *p, float *j, int m, int n, void *adata),  
                             float *p, float *x, int m, int n, float *lb, float *ub,
-                            int itmax, float *opts, float *info, float *work, float *covar, void *adata);
+                            int itmax, float opts[4], float info[LM_INFO_SZ], float *work, float *covar, void *adata);
 
   extern int slevmar_bc_dif(
                             void (*func)(float *p, float *hx, int m, int n, void *adata),
                             float *p, float *x, int m, int n, float *lb, float *ub,
-                            int itmax, float *opts, float *info, float *work, float *covar, void *adata);
+                            int itmax, float opts[5], float info[LM_INFO_SZ], float *work, float *covar, void *adata);
 
 #ifdef HAVE_LAPACK
   /* linear equation constrained minimization */
@@ -120,12 +120,12 @@ extern "C" {
                              void (*func)(float *p, float *hx, int m, int n, void *adata),
                              void (*jacf)(float *p, float *j, int m, int n, void *adata),
                              float *p, float *x, int m, int n, float *A, float *b, int k,
-                             int itmax, float *opts, float *info, float *work, float *covar, void *adata);
+                             int itmax, float opts[4], float info[LM_INFO_SZ], float *work, float *covar, void *adata);
 
   extern int slevmar_lec_dif(
                              void (*func)(float *p, float *hx, int m, int n, void *adata),
                              float *p, float *x, int m, int n, float *A, float *b, int k,
-                             int itmax, float *opts, float *info, float *work, float *covar, void *adata);
+                             int itmax, float opts[5], float info[LM_INFO_SZ], float *work, float *covar, void *adata);
 #endif /* HAVE LAPACK */
 
   /* linear system solvers */


### PR DESCRIPTION
## Summary
- align `opts` and `info` parameter declarations in `lm.h` with
  implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fb065b848325bba7eeb778bbb65c