### PR TITLE
Fix allocation size for long double parameters

### DIFF
--- a/SDDSaps/sddsmakedataset.c
+++ b/SDDSaps/sddsmakedataset.c
@@ -677,7 +677,7 @@ void SetInfoData(PARAMETER_INFO **parameter, long parameters, COLUMN_INFO **colu
       fprintf(stderr, "Error: Invalid data type '%s' for parameter '%s'.\n", type, par->name);
       exit(EXIT_FAILURE);
     }
-    par->data = malloc(sizeof(double)); /* Temporary allocation, actual type handled below */
+    par->data = malloc(SDDS_type_size[par->type - 1]);
     if (!par->data) {
       fprintf(stderr, "Error: Memory allocation failed for parameter data.\n");
       exit(EXIT_FAILURE);


### PR DESCRIPTION
## Summary
- allocate parameter memory using `SDDS_type_size`
- prevents out-of-bounds writes when handling `long double` data

## Testing
- `gcc -Wall -Wextra -Iinclude -Imdbcommon -ISDDSlib -ISDDSaps -c SDDSaps/sddsmakedataset.c -o /tmp/sddsmakedataset.o`

------
https://chatgpt.com/codex/tasks/task_e_684308b992d88325a21c61755c4b35a0