### PR TITLE
Fix snprintf buffer size

### DIFF
--- a/SDDSaps/sddscontours/sddsimageconvert.c
+++ b/SDDSaps/sddscontours/sddsimageconvert.c
@@ -541,12 +541,12 @@ long ConvertSDDSsingleColumnImage(SDDS_DATASET *SDDS_orig, SDDS_DATASET *SDDS_da
         intlength = strlen(buffer);
       }
       for (n = 0; n < yDimension; n++) {
-        lineColumnNames[n] = malloc(sizeof(char) * 40);
+        lineColumnNames[n] = malloc(sizeof(char) * 128);
 
         if (intlength) {
-          snprintf(lineColumnNames[n], 64, "%s%0*ld", prefix, (int)intlength, (long)(n * yInterval + yMinimum));
+          snprintf(lineColumnNames[n], 128, "%s%0*ld", prefix, (int)intlength, (long)(n * yInterval + yMinimum));
         } else {
-          snprintf(lineColumnNames[n], 64, "%s%g", prefix, n * yInterval + yMinimum);
+          snprintf(lineColumnNames[n], 128, "%s%g", prefix, n * yInterval + yMinimum);
         }
         if (SDDS_DefineSimpleColumn(SDDS_dataset, lineColumnNames[n], NULL, SDDS_DOUBLE) == 0) {
           SDDS_PrintErrors(stderr, SDDS_VERBOSE_PrintErrors);


### PR DESCRIPTION
## Summary
- fix compiler warnings in `sddsimageconvert.c`

## Testing
- `pytest -q`
- `gcc -c -Wall -Wextra -Wformat-truncation -O2 -Iinclude SDDSaps/sddscontours/sddsimageconvert.c`

------
https://chatgpt.com/codex/tasks/task_e_68430880e16c8325866cf18d51c039ba