### PR TITLE
Fix unused-result warnings

### DIFF
--- a/SDDSaps/mcs2sdds.c
+++ b/SDDSaps/mcs2sdds.c
@@ -157,50 +157,83 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  fread(&trigger, sizeof(char), 1, fpi);     /* Read Trigger Flag */
-  fread(&dwell_flag, sizeof(char), 1, fpi);  /* Read dwell flag */
-  fread(&dwell_units, sizeof(char), 1, fpi); /* Read dwell units */
-  fread(&acq_mode, sizeof(char), 1, fpi);
-  fread(&dwell_913, sizeof(long), 1, fpi);
+  bytesRead = fread(&trigger, sizeof(char), 1, fpi);     /* Read Trigger Flag */
+  (void)bytesRead;
+  bytesRead = fread(&dwell_flag, sizeof(char), 1, fpi);  /* Read dwell flag */
+  (void)bytesRead;
+  bytesRead = fread(&dwell_units, sizeof(char), 1, fpi); /* Read dwell units */
+  (void)bytesRead;
+  bytesRead = fread(&acq_mode, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&dwell_913, sizeof(long), 1, fpi);
+  (void)bytesRead;
   swapulong(&dwell_913);
-  fread(&pass_length, sizeof(short), 1, fpi);
+  bytesRead = fread(&pass_length, sizeof(short), 1, fpi);
+  (void)bytesRead;
   swapushort(&pass_length);
-  fread(&pass_count, sizeof(long), 1, fpi);
+  bytesRead = fread(&pass_count, sizeof(long), 1, fpi);
+  (void)bytesRead;
   swapulong(&pass_count);
-  fread(&pass_count_preset, sizeof(long), 1, fpi);
+  bytesRead = fread(&pass_count_preset, sizeof(long), 1, fpi);
+  (void)bytesRead;
   swapulong(&pass_count_preset);
-  fread(acq_time, sizeof(char), 8, fpi);
-  fread(acq_date, sizeof(char), 8, fpi);
-  fread(&mark_chan, sizeof(short), 1, fpi);
+  bytesRead = fread(acq_time, sizeof(char), 8, fpi);
+  (void)bytesRead;
+  bytesRead = fread(acq_date, sizeof(char), 8, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&mark_chan, sizeof(short), 1, fpi);
+  (void)bytesRead;
   swapushort(&mark_chan);
-  fread(&mcs_num, sizeof(char), 1, fpi);
-  fread(&cal_flag, sizeof(char), 1, fpi);
-  fread(cal_units, sizeof(char), 4, fpi);
-  fread(&cal_zero, sizeof(float), 1, fpi);
+  bytesRead = fread(&mcs_num, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&cal_flag, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(cal_units, sizeof(char), 4, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&cal_zero, sizeof(float), 1, fpi);
+  (void)bytesRead;
   swapfloat(&cal_zero);
-  fread(&cal_slope, sizeof(float), 1, fpi);
+  bytesRead = fread(&cal_slope, sizeof(float), 1, fpi);
+  (void)bytesRead;
   swapfloat(&cal_slope);
-  fread(reserved, sizeof(char), 10, fpi);
-  fread(&id_byte, sizeof(char), 1, fpi);
-  fread(reserved, sizeof(char), 1, fpi);
-  fread(&detector_len, sizeof(char), 1, fpi);
-  fread(detector, sizeof(char), 63, fpi);
-  fread(&sample_len, sizeof(char), 1, fpi);
-  fread(sample, sizeof(char), 63, fpi);
-  fread(reserved, sizeof(char), 16, fpi); /* skip view info & reserved */
-  fread(&disc_sel, sizeof(char), 1, fpi);
-  fread(&disc_edge, sizeof(char), 1, fpi);
-  fread(&disc, sizeof(float), 1, fpi);
+  bytesRead = fread(reserved, sizeof(char), 10, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&id_byte, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(reserved, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&detector_len, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(detector, sizeof(char), 63, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&sample_len, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(sample, sizeof(char), 63, fpi);
+  (void)bytesRead;
+  bytesRead = fread(reserved, sizeof(char), 16, fpi); /* skip view info & reserved */
+  (void)bytesRead;
+  bytesRead = fread(&disc_sel, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&disc_edge, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(&disc, sizeof(float), 1, fpi);
+  (void)bytesRead;
   swapfloat(&disc);
-  fread(&sca_uld, sizeof(float), 1, fpi);
+  bytesRead = fread(&sca_uld, sizeof(float), 1, fpi);
+  (void)bytesRead;
   swapfloat(&sca_uld);
-  fread(&sca_lld, sizeof(float), 1, fpi);
+  bytesRead = fread(&sca_lld, sizeof(float), 1, fpi);
+  (void)bytesRead;
   swapfloat(&sca_lld);
-  fread(&dwell, sizeof(float), 1, fpi);
+  bytesRead = fread(&dwell, sizeof(float), 1, fpi);
+  (void)bytesRead;
   swapfloat(&dwell);
-  fread(&consistent, sizeof(char), 1, fpi);
-  fread(reserved, sizeof(char), 21, fpi);
-  fread(mcs_id, sizeof(char), 8, fpi);
+  bytesRead = fread(&consistent, sizeof(char), 1, fpi);
+  (void)bytesRead;
+  bytesRead = fread(reserved, sizeof(char), 21, fpi);
+  (void)bytesRead;
+  bytesRead = fread(mcs_id, sizeof(char), 8, fpi);
+  (void)bytesRead;
   mcs_id[8] = '\0';
 
   sprintf(ts1, "%d", mcs_num + 1);

--- a/SDDSaps/sddsplots/qtDriver/mpl_qt_readdata.cc
+++ b/SDDSaps/sddsplots/qtDriver/mpl_qt_readdata.cc
@@ -112,7 +112,8 @@ long readdata() {
     bufptr += sizeof(char);
     curwrite->nc++;
     if (numvals) {
-      fread(bufptr, sizeof(VTYPE) * numvals, 1, input);
+      if (fread(bufptr, sizeof(VTYPE) * numvals, 1, input) != 1)
+        return 1;
       bufptr += step;
       curwrite->nc += step;
     }

--- a/SDDSaps/tdms2sdds.c
+++ b/SDDSaps/tdms2sdds.c
@@ -765,15 +765,19 @@ int main(int argc, char **argv) {
 
 void TDMS_ReadLeadIn(FILE *fd, TDMS_SEGMENT *segment) {
   char buffer[50];
+  size_t bytesRead;
 
-  fread(buffer, 1, 4, fd);
+  bytesRead = fread(buffer, 1, 4, fd);
+  (void)bytesRead;
   buffer[4] = '\0';
   if (strcmp(buffer, "TDSm") != 0) {
     fprintf(stderr, "tdms2sdds: Error: File does not start with TDSm\n");
     exit(EXIT_FAILURE);
   }
-  fread(&(segment->lead_in.toc), 1, 4, fd);     /* TOC */
-  fread(&(segment->lead_in.version), 1, 4, fd); /* Version */
+  bytesRead = fread(&(segment->lead_in.toc), 1, 4, fd);     /* TOC */
+  (void)bytesRead;
+  bytesRead = fread(&(segment->lead_in.version), 1, 4, fd); /* Version */
+  (void)bytesRead;
   if (segment->lead_in.version == 4712) {
     fprintf(stderr, "tdms2sdds: Error: TDMS version 1.0 files unsupported\n");
     exit(EXIT_FAILURE);
@@ -782,12 +786,15 @@ void TDMS_ReadLeadIn(FILE *fd, TDMS_SEGMENT *segment) {
     fprintf(stderr, "tdms2sdds: Error: Unknown TDMS version\n");
     exit(EXIT_FAILURE);
   }
-  fread(&(segment->lead_in.next_segment_offset), 1, 8, fd); /* Next segment offset */
-  fread(&(segment->lead_in.raw_data_offset), 1, 8, fd);     /* Raw data offset */
+  bytesRead = fread(&(segment->lead_in.next_segment_offset), 1, 8, fd); /* Next segment offset */
+  (void)bytesRead;
+  bytesRead = fread(&(segment->lead_in.raw_data_offset), 1, 8, fd);     /* Raw data offset */
+  (void)bytesRead;
 }
 
 void TDMS_ReadMetaData(FILE *fd, TDMS_SEGMENT *segment) {
   uint32_t uLong, i, j;
+  size_t bytesRead;
 
   segment->xpart.name = NULL;
   segment->xpart.unit = NULL;
@@ -798,35 +805,49 @@ void TDMS_ReadMetaData(FILE *fd, TDMS_SEGMENT *segment) {
   segment->xpart.time_pref = NULL;
   segment->xpart.range = 0;
 
-  fread(&(segment->meta_data.n_objects), 1, 4, fd);
+  bytesRead = fread(&(segment->meta_data.n_objects), 1, 4, fd);
+  (void)bytesRead;
 
   segment->meta_data.object = malloc(sizeof(TDMS_META_DATA_OBJECT) * segment->meta_data.n_objects);
   for (i = 0; i < segment->meta_data.n_objects; i++) {
-    fread(&uLong, 1, 4, fd);
+    bytesRead = fread(&uLong, 1, 4, fd);
+    (void)bytesRead;
     segment->meta_data.object[i].path = malloc(sizeof(char) * (uLong + 1));
-    fread(segment->meta_data.object[i].path, 1, uLong, fd);
+    bytesRead = fread(segment->meta_data.object[i].path, 1, uLong, fd);
+    (void)bytesRead;
     segment->meta_data.object[i].path[uLong] = '\0';
-    fread(&(segment->meta_data.object[i].raw_data_index), 1, 4, fd);
+    bytesRead = fread(&(segment->meta_data.object[i].raw_data_index), 1, 4, fd);
+    (void)bytesRead;
     if ((segment->meta_data.object[i].raw_data_index != 0xFFFFFFFF) && (segment->meta_data.object[i].raw_data_index != 0x00000000)) {
-      fread(&(segment->meta_data.object[i].raw_data_datatype), 1, 4, fd);
-      fread(&(segment->meta_data.object[i].raw_data_dimensions), 1, 4, fd);
-      fread(&(segment->meta_data.object[i].raw_data_count), 1, 8, fd);
+      bytesRead = fread(&(segment->meta_data.object[i].raw_data_datatype), 1, 4, fd);
+      (void)bytesRead;
+      bytesRead = fread(&(segment->meta_data.object[i].raw_data_dimensions), 1, 4, fd);
+      (void)bytesRead;
+      bytesRead = fread(&(segment->meta_data.object[i].raw_data_count), 1, 8, fd);
+      (void)bytesRead;
       if (segment->meta_data.object[i].raw_data_datatype == tdsTypeString) {
-        fread(&(segment->meta_data.object[i].raw_data_total_size), 1, 8, fd);
+        bytesRead = fread(&(segment->meta_data.object[i].raw_data_total_size), 1, 8, fd);
+        (void)bytesRead;
       }
     }
-    fread(&(segment->meta_data.object[i].n_properties), 1, 4, fd);
+    bytesRead = fread(&(segment->meta_data.object[i].n_properties), 1, 4, fd);
+    (void)bytesRead;
     segment->meta_data.object[i].property = malloc(sizeof(TDMS_META_DATA_OBJECT_PROPERTY) * segment->meta_data.object[i].n_properties);
     for (j = 0; j < segment->meta_data.object[i].n_properties; j++) {
-      fread(&uLong, 1, 4, fd);
+      bytesRead = fread(&uLong, 1, 4, fd);
+      (void)bytesRead;
       segment->meta_data.object[i].property[j].name = malloc(sizeof(char) * (uLong + 1));
-      fread(segment->meta_data.object[i].property[j].name, 1, uLong, fd);
+      bytesRead = fread(segment->meta_data.object[i].property[j].name, 1, uLong, fd);
+      (void)bytesRead;
       segment->meta_data.object[i].property[j].name[uLong] = '\0';
-      fread(&(segment->meta_data.object[i].property[j].datatype), 1, 4, fd);
+      bytesRead = fread(&(segment->meta_data.object[i].property[j].datatype), 1, 4, fd);
+      (void)bytesRead;
       if (segment->meta_data.object[i].property[j].datatype == tdsTypeString) {
-        fread(&uLong, 1, 4, fd);
+        bytesRead = fread(&uLong, 1, 4, fd);
+        (void)bytesRead;
         segment->meta_data.object[i].property[j].value = malloc(sizeof(char) * (uLong + 1));
-        fread(segment->meta_data.object[i].property[j].value, 1, uLong, fd);
+        bytesRead = fread(segment->meta_data.object[i].property[j].value, 1, uLong, fd);
+        (void)bytesRead;
         ((char *)(segment->meta_data.object[i].property[j].value))[uLong] = '\0';
       } else {
         TDMS_GetValue(fd, &(segment->meta_data.object[i].property[j].value), segment->meta_data.object[i].property[j].datatype);
@@ -868,6 +889,7 @@ void TDMS_ReadRawData(FILE *fd, TDMS_FILE *tdms, uint32_t n_segment, long filesi
   uint64_t uLLong;
   int prevFound = 0;
   TDMS_SEGMENT *segment = &((*tdms).segment[n_segment]);
+  size_t bytesRead;
 
   segment->raw_data.n_channels = 0;
   for (i = 0; i < segment->meta_data.n_objects; i++) {
@@ -1054,54 +1076,54 @@ void TDMS_ReadRawData(FILE *fd, TDMS_FILE *tdms, uint32_t n_segment, long filesi
         if (segment->meta_data.object[i].raw_data_index != 0xFFFFFFFF) {
           if (segment->meta_data.object[i].raw_data_datatype == tdsTypeBoolean) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((int8_t *)(segment->raw_data.channel[j].values))[k]), 1, 1, fd);
+              bytesRead = fread(&(((int8_t *)(segment->raw_data.channel[j].values))[k]), 1, 1, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeI8) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((int8_t *)(segment->raw_data.channel[j].values))[k]), 1, 1, fd);
+              bytesRead = fread(&(((int8_t *)(segment->raw_data.channel[j].values))[k]), 1, 1, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeU8) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((uint8_t *)(segment->raw_data.channel[j].values))[k]), 1, 1, fd);
+              bytesRead = fread(&(((uint8_t *)(segment->raw_data.channel[j].values))[k]), 1, 1, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeI16) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((int16_t *)(segment->raw_data.channel[j].values))[k]), 1, 2, fd);
+              bytesRead = fread(&(((int16_t *)(segment->raw_data.channel[j].values))[k]), 1, 2, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeU16) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((uint16_t *)(segment->raw_data.channel[j].values))[k]), 1, 2, fd);
+              bytesRead = fread(&(((uint16_t *)(segment->raw_data.channel[j].values))[k]), 1, 2, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeI32) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((int32_t *)(segment->raw_data.channel[j].values))[k]), 1, 4, fd);
+              bytesRead = fread(&(((int32_t *)(segment->raw_data.channel[j].values))[k]), 1, 4, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeU32) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((uint32_t *)(segment->raw_data.channel[j].values))[k]), 1, 4, fd);
+              bytesRead = fread(&(((uint32_t *)(segment->raw_data.channel[j].values))[k]), 1, 4, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeI64) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((int64_t *)(segment->raw_data.channel[j].values))[k]), 1, 8, fd);
+              bytesRead = fread(&(((int64_t *)(segment->raw_data.channel[j].values))[k]), 1, 8, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeU64) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((uint64_t *)(segment->raw_data.channel[j].values))[k]), 1, 8, fd);
+              bytesRead = fread(&(((uint64_t *)(segment->raw_data.channel[j].values))[k]), 1, 8, fd);
             }
           } else if ((segment->meta_data.object[i].raw_data_datatype == tdsTypeSingleFloat) ||
                      (segment->meta_data.object[i].raw_data_datatype == tdsTypeSingleFloatWithUnit)) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((float *)(segment->raw_data.channel[j].values))[k]), 1, 4, fd);
+              bytesRead = fread(&(((float *)(segment->raw_data.channel[j].values))[k]), 1, 4, fd);
             }
           } else if ((segment->meta_data.object[i].raw_data_datatype == tdsTypeDoubleFloat) ||
                      (segment->meta_data.object[i].raw_data_datatype == tdsTypeDoubleFloatWithUnit)) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&(((double *)(segment->raw_data.channel[j].values))[k]), 1, 8, fd);
+              bytesRead = fread(&(((double *)(segment->raw_data.channel[j].values))[k]), 1, 8, fd);
             }
           } else if (segment->meta_data.object[i].raw_data_datatype == tdsTypeTimeStamp) {
             for (k = chunk * segment->meta_data.object[i].raw_data_count; k < (chunk + 1) * segment->meta_data.object[i].raw_data_count; k++) {
-              fread(&uLLong, 1, 8, fd);
-              fread(&LLong, 1, 8, fd);
+              bytesRead = fread(&uLLong, 1, 8, fd);
+              bytesRead = fread(&LLong, 1, 8, fd);
               /*LLong = LLong - 2082844791LL; */ /* Subtract seconds between 1904 and 1970 */
               segment->raw_data.channel[j].values[k] = LLong + (uLLong * 5.42101086242752217e-20);
             }
@@ -1137,41 +1159,41 @@ void TDMS_GetValue(FILE *fd, void **value, int32_t datatype) {
 
   if (datatype == tdsTypeI8) {
     *value = malloc(sizeof(int8_t));
-    fread(((int8_t *)(*value)), 1, 1, fd);
+    bytesRead = fread(((int8_t *)(*value)), 1, 1, fd);
   } else if (datatype == tdsTypeU8) {
     *value = malloc(sizeof(uint8_t));
-    fread(((uint8_t *)(*value)), 1, 1, fd);
+    bytesRead = fread(((uint8_t *)(*value)), 1, 1, fd);
   } else if (datatype == tdsTypeI16) {
     *value = malloc(sizeof(int16_t));
-    fread(((int16_t *)(*value)), 1, 2, fd);
+    bytesRead = fread(((int16_t *)(*value)), 1, 2, fd);
   } else if (datatype == tdsTypeU16) {
     *value = malloc(sizeof(uint16_t));
-    fread(((uint16_t *)(*value)), 1, 2, fd);
+    bytesRead = fread(((uint16_t *)(*value)), 1, 2, fd);
   } else if (datatype == tdsTypeI32) {
     *value = malloc(sizeof(int32_t));
-    fread(((int32_t *)(*value)), 1, 4, fd);
+    bytesRead = fread(((int32_t *)(*value)), 1, 4, fd);
   } else if (datatype == tdsTypeU32) {
     *value = malloc(sizeof(uint32_t));
-    fread(((uint32_t *)(*value)), 1, 4, fd);
+    bytesRead = fread(((uint32_t *)(*value)), 1, 4, fd);
   } else if (datatype == tdsTypeI64) {
     *value = malloc(sizeof(int64_t));
-    fread(((int64_t *)(*value)), 1, 8, fd);
+    bytesRead = fread(((int64_t *)(*value)), 1, 8, fd);
   } else if (datatype == tdsTypeU64) {
     *value = malloc(sizeof(uint64_t));
-    fread(((uint64_t *)(*value)), 1, 8, fd);
+    bytesRead = fread(((uint64_t *)(*value)), 1, 8, fd);
   } else if ((datatype == tdsTypeSingleFloat) || (datatype == tdsTypeSingleFloatWithUnit)) {
     *value = malloc(sizeof(float));
-    fread(((float *)(*value)), 1, 4, fd);
+    bytesRead = fread(((float *)(*value)), 1, 4, fd);
   } else if ((datatype == tdsTypeDoubleFloat) || (datatype == tdsTypeDoubleFloatWithUnit)) {
     *value = malloc(sizeof(double));
-    fread(((double *)(*value)), 1, 8, fd);
+    bytesRead = fread(((double *)(*value)), 1, 8, fd);
   } else if (datatype == tdsTypeBoolean) {
     *value = malloc(sizeof(int8_t));
-    fread(((int8_t *)(*value)), 1, 1, fd);
+    bytesRead = fread(((int8_t *)(*value)), 1, 1, fd);
   } else if (datatype == tdsTypeTimeStamp) {
     *value = malloc(sizeof(double));
-    fread(&uLLong, 1, 8, fd);
-    fread(&LLong, 1, 8, fd);
+    bytesRead = fread(&uLLong, 1, 8, fd);
+    bytesRead = fread(&LLong, 1, 8, fd);
     /*LLong = LLong - 2082844791LL; */ /* Subtract seconds between 1904 and 1970 */
     *((double *)(*value)) = LLong + (uLLong * 5.42101086242752217e-20);
   } else if (datatype == tdsTypeVoid) {

--- a/SDDSaps/tek2sdds.c
+++ b/SDDSaps/tek2sdds.c
@@ -138,6 +138,7 @@ int main(int argc, char **argv) {
   double *time, *data;
   short columnMajorOrder = 0;
   unsigned long majorOrderFlag;
+  size_t bytesRead;
 
   xUnits = yUnits = NULL;
 
@@ -327,7 +328,8 @@ int main(int argc, char **argv) {
     }
   } else {
     short sdata;
-    fread(buffer, sizeof(char), 4, fpi);
+    bytesRead = fread(buffer, sizeof(char), 4, fpi);
+    (void)bytesRead;
     for (i = 0; i < points; i++) {
       if (fread(&sdata, sizeof(sdata), 1, fpi) != 1) {
         fprintf(stderr, "file ends unexpectedly\n");

--- a/include/mdb.h
+++ b/include/mdb.h
@@ -648,11 +648,25 @@ epicsShareFuncMDBLIB void *trealloc(void *ptr, uint64_t size_of_block);
 /* String-related macro definitions: */
 #define chop_nl(m_s) ( ((m_s)[strlen(m_s)-1]=='\n') ? (m_s)[strlen(m_s)-1]=0 : 0)
 
-#define queryn(s, t, n) ((*(t)=0),fputs(s,stdout),fgets(t,n,stdin),chop_nl(t))
-#define queryn_e(s, t, n) ((*(t)=0),fputs(s,stderr),fgets(t,n,stdin),chop_l(t))
+#define queryn(s, t, n) (queryn_func((s), (t), (n)))
+#define queryn_e(s, t, n) (queryn_e_func((s), (t), (n)))
 
 #define is_yes(c) ((c)=='y' || (c)=='Y')
 #define is_no(c) ((c)=='n' || (c)=='N')
+
+static inline void queryn_func(const char *s, char *t, int n) {
+  *t = 0;
+  fputs(s, stdout);
+  if (fgets(t, n, stdin))
+    chop_nl(t);
+}
+
+static inline void queryn_e_func(const char *s, char *t, int n) {
+  *t = 0;
+  fputs(s, stderr);
+  if (fgets(t, n, stdin))
+    chop_nl(t);
+}
 
 /*   -- Data-scanning routines: */
 epicsShareFuncMDBLIB extern long   query_long(char *prompt, long default_value);

--- a/meschach/matlab.c
+++ b/meschach/matlab.c
@@ -166,13 +166,16 @@ char    **name;
 	A = m_get((unsigned)(mat.m),(unsigned)(mat.n));
 	for ( i = 0; i < A->m*A->n; i++ )
 	{
-		if ( p_flag == DOUBLE_PREC )
-		    fread(&d_temp,sizeof(double),1,fp);
-		else
-		{
-		    fread(&f_temp,sizeof(float),1,fp);
-		    d_temp = f_temp;
-		}
+                if ( p_flag == DOUBLE_PREC ) {
+                    size_t r = fread(&d_temp, sizeof(double), 1, fp);
+                    (void)r;
+                }
+                else
+                {
+                    size_t r = fread(&f_temp, sizeof(float), 1, fp);
+                    (void)r;
+                    d_temp = f_temp;
+                }
 		if ( o_flag == ROW_ORDER )
 		    A->me[i / A->n][i % A->n] = d_temp;
 		else if ( o_flag == COL_ORDER )
@@ -184,10 +187,13 @@ char    **name;
 	if ( mat.imag )         /* skip imaginary part */
 	for ( i = 0; i < A->m*A->n; i++ )
 	{
-		if ( p_flag == DOUBLE_PREC )
-		    fread(&d_temp,sizeof(double),1,fp);
-		else
-		    fread(&f_temp,sizeof(float),1,fp);
+                if ( p_flag == DOUBLE_PREC ) {
+                    size_t r = fread(&d_temp, sizeof(double), 1, fp);
+                    (void)r;
+                } else {
+                    size_t r = fread(&f_temp, sizeof(float), 1, fp);
+                    (void)r;
+                }
 	}
 
 	return A;

--- a/meschach/matrixio.c
+++ b/meschach/matrixio.c
@@ -133,7 +133,10 @@ MAT     *mat;
 	       } while ( *line=='\0' || sscanf(line,"%f",&mat->me[i][j])<1 );
 #endif
 	  fprintf(stderr,"Continue: ");
-	  fscanf(fp,"%c",&c);
+          {
+            int rv = fscanf(fp, "%c", &c);
+            (void)rv;
+          }
 	  if ( c == 'n' || c == 'N' )
 	  {    dynamic = FALSE;                 goto redo;      }
 	  if ( (c == 'b' || c == 'B') /* && i > 0 */ )

--- a/meschach/sparseio.c
+++ b/meschach/sparseio.c
@@ -258,7 +258,10 @@ FILE    *fp;
 	{
 	        ret_val = 0;
 		skipjunk(fp);
-		fscanf(fp,"SparseMatrix:");
+                {
+                    int rv = fscanf(fp, "SparseMatrix:");
+                    (void)rv;
+                }
 		skipjunk(fp);
 		if ( (ret_val=fscanf(fp,"%u by %u",&m,&n)) != 2 )
 		    error((ret_val == EOF) ? E_EOF : E_FORMAT,"sp_finput");
@@ -274,17 +277,17 @@ FILE    *fp;
 		    /* printf("Reading row # %d\n",i); */
 		    rows[i].diag = -1;
 		    skipjunk(fp);
-		    if ( (ret_val=fscanf(fp,"row %d :",&tmp)) != 1 ||
-			 tmp != i )
-			error((ret_val == EOF) ? E_EOF : E_FORMAT,
-			      "sp_finput");
+                    if ( (ret_val=fscanf(fp, "row %d :", &tmp)) != 1 ||
+                         tmp != i )
+                        error((ret_val == EOF) ? E_EOF : E_FORMAT,
+                              "sp_finput");
 		    curr_col = -1;
 		    for ( len = 0; len < MAXSCRATCH; len++ )
 		    {
 #if REAL == DOUBLE
-			if ( (ret_val=fscanf(fp,"%u : %lf",&col,&val)) != 2 )
+                        if ( (ret_val=fscanf(fp, "%u : %lf", &col, &val)) != 2 )
 #elif REAL == FLOAT
-			if ( (ret_val=fscanf(fp,"%u : %f",&col,&val)) != 2 )
+                        if ( (ret_val=fscanf(fp, "%u : %f", &col, &val)) != 2 )
 #endif
 			    break;
 			if ( col <= curr_col || col >= n )

--- a/meschach/zmatio.c
+++ b/meschach/zmatio.c
@@ -137,7 +137,10 @@ ZMAT     *mat;
 #endif	
 				&mat->me[i][j].re,&mat->me[i][j].im)<1 );
 	  fprintf(stderr,"Continue: ");
-	  fscanf(fp,"%c",&c);
+          {
+            int rv = fscanf(fp, "%c", &c);
+            (void)rv;
+          }
 	  if ( c == 'n' || c == 'N' )
 	  {    dynamic = FALSE;                 goto redo;      }
 	  if ( (c == 'b' || c == 'B') /* && i > 0 */ )

--- a/meschach/zmatlab.c
+++ b/meschach/zmatlab.c
@@ -175,13 +175,16 @@ char    **name;
     A = zm_get((unsigned)(mat.m),(unsigned)(mat.n));
     for ( i = 0; i < A->m*A->n; i++ )
     {
-	if ( p_flag == DOUBLE_PREC )
-	    fread(&d_temp,sizeof(double),1,fp);
-	else
-	{
-	    fread(&f_temp,sizeof(float),1,fp);
-	    d_temp = f_temp;
-	}
+        if ( p_flag == DOUBLE_PREC ) {
+            size_t r = fread(&d_temp, sizeof(double), 1, fp);
+            (void)r;
+        }
+        else
+        {
+            size_t r = fread(&f_temp, sizeof(float), 1, fp);
+            (void)r;
+            d_temp = f_temp;
+        }
 	if ( o_flag == ROW_ORDER )
 	    A->me[i / A->n][i % A->n].re = d_temp;
 	else if ( o_flag == COL_ORDER )
@@ -193,13 +196,14 @@ char    **name;
     if ( mat.imag )         /* skip imaginary part */
 	for ( i = 0; i < A->m*A->n; i++ )
 	{
-	    if ( p_flag == DOUBLE_PREC )
-		fread(&d_temp,sizeof(double),1,fp);
-	    else
-	    {
-		fread(&f_temp,sizeof(float),1,fp);
-		d_temp = f_temp;
-	    }
+            if ( p_flag == DOUBLE_PREC ) {
+                size_t r = fread(&d_temp, sizeof(double), 1, fp);
+                (void)r;
+            } else {
+                size_t r = fread(&f_temp, sizeof(float), 1, fp);
+                (void)r;
+                d_temp = f_temp;
+            }
 	    if ( o_flag == ROW_ORDER )
 		A->me[i / A->n][i % A->n].im = d_temp;
 	    else if ( o_flag == COL_ORDER )

--- a/namelist/namelist_pp.c
+++ b/namelist/namelist_pp.c
@@ -356,7 +356,8 @@ char *efgets(char *s, long n, FILE *fp)
         return(s);
     while (!has_semicolon(sr)) {
         sr = s + strlen(s);
-        fgets(sr, n, fp);
+        if (!fgets(sr, n, fp))
+            return NULL;
         }
     return(s);
     }

--- a/namelist/scanargs.c
+++ b/namelist/scanargs.c
@@ -305,7 +305,8 @@ void prompt_for_arguments(int *argc, char ***argv)
     tfree(cmd_line_arg);
 
     do {
-        fgets(buffer, 1024, stdin);
+        if (!fgets(buffer, 1024, stdin))
+            return;
         buffer[strlen(buffer)-1] = 0;
         while ((ptr=get_token_tq(buffer, " ", " ", "\"", "\""))) {
             if (*ptr=='&')

--- a/rpns/code/udf.c
+++ b/rpns/code/udf.c
@@ -158,7 +158,8 @@ void make_udf(void)
   if (istackptr==1)
     queryn("function name: ", name, 20);
   else {
-    fgets(name, 20, input_stack[istackptr-1].fp);
+    if (!fgets(name, 20, input_stack[istackptr-1].fp))
+      return;
     chop_nl(name);
     if (input_stack[istackptr-1].filemode==ECHO)
       puts(name);

--- a/utils/replaceText.c
+++ b/utils/replaceText.c
@@ -220,14 +220,16 @@ int main(
           fprintf(stderr, "Old : %s", s0);
           fprintf(stderr, "New : %s", t);
           fprintf(stderr, "Keep change? (y=yes/e=edit/<enter>=no) ");
-          fgets(response, 10, stdin);
+          if (!fgets(response, 10, stdin))
+            return 1;
           if (response[0]=='y' || response[0]=='Y') {
             /* Update s to contain newest changes */
             strcpy_ss(s, t);
           } else if (response[0]=='e' || response[0]=='E') {
             /* Give user opportunity to change the string */
             fprintf(stderr, "Please enter new string:");
-            fgets(s, 1024, stdin);
+            if (!fgets(s, 1024, stdin))
+              return 1;
           } else {
             strcpy_ss(s, s0);
           }


### PR DESCRIPTION
## Summary
- add helper functions for queryn/queryn_e
- check or ignore the return value from various fread/fscanf/fgets calls
- silence all `-Wunused-result` warnings

## Testing
- `make -j`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843083e71f48325aee62addc4c6a3e0