### PR TITLE
Fix compiler warnings for system call results

### DIFF
--- a/SDDSaps/sddslogserver.c
+++ b/SDDSaps/sddslogserver.c
@@ -285,7 +285,8 @@ int main(int argc, char *argv[]) {
   }
   if (!fexists(rootDir))
     error("Error: Root directory not found", argv[0]);
-  chdir(rootDir);
+  if (chdir(rootDir) != 0)
+    perror("chdir");
 
   /* Create socket */
   sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -508,7 +509,10 @@ int createChannel(char *spec)
     return 6;
 
   snprintf(buffer, sizeof(buffer), "sddsquery %s.sdds -sddsOutput=%s.chd -column", chName, chName);
-  system(buffer);
+  {
+    int sysret = system(buffer);
+    (void)sysret;
+  }
   snprintf(buffer, sizeof(buffer), "%s.chd", chName);
   if (!fexists(buffer))
     return 6;
@@ -520,7 +524,10 @@ int createChannel(char *spec)
 
 void updateChannelDescription(void) {
   char *command = "sddscombine *.chd -merge -pipe=out | sddsprocess -pipe=in -match=col,Name=SampleIDNumber,! -match=col,Name=Time,! allChd.sdds";
-  system(command);
+  {
+    int sysret = system(command);
+    (void)sysret;
+  }
 }
 
 int addValue(char *spec)
@@ -718,7 +725,10 @@ int makeDirectoryList(int64_t *returnNumber, char ***returnBuffer) {
   remove("dirList.sdds");
   snprintf(command, sizeof(command),
            "find . -type d -maxdepth 1 | tail -n +2 | plaindata2sdds -pipe=in dirList.sdds -input=ascii -column=DirectoryName,string -norow");
-  system(command);
+  {
+    int sysret = system(command);
+    (void)sysret;
+  }
   if (!SDDS_InitializeInput(&SDDSin, "dirList.sdds")) {
     printf("Problem reading dirList.sdds\n");
     SDDS_PrintErrors(stderr, SDDS_VERBOSE_PrintErrors);

--- a/SDDSaps/sddsplots/png.trm
+++ b/SDDSaps/sddsplots/png.trm
@@ -412,7 +412,10 @@ int PNG_movie(void)
      snprintf(command, sizeof(command),
              "ffmpeg -y -framerate %d -i %s -c:v libx264 -pix_fmt yuv420p %s",
              fps, pngTemplate, filename);
-     system(command);
+     {
+       int sysret = system(command);
+       (void)sysret;
+     }
      for (i=1; i<pngGeneration; i++) {
        sprintf(filename, pngTemplate, i);
        remove(filename);

--- a/SDDSaps/sddsplots/qtDriver/mpl_qt_zoom.cc
+++ b/SDDSaps/sddsplots/qtDriver/mpl_qt_zoom.cc
@@ -180,7 +180,8 @@ void newzoom() {
   
   strcat(cmd, " -output=");
   strcat(cmd, tempFile.fileName().toUtf8().constData());
-  system(cmd);
+  int sysret = system(cmd);
+  (void)sysret;
   free(cmd);
   do {
     if (fexists(tempFile.fileName().toUtf8().constData()))

--- a/SDDSaps/tdms2sdds.c
+++ b/SDDSaps/tdms2sdds.c
@@ -876,6 +876,7 @@ void TDMS_ReadMetaData(FILE *fd, TDMS_SEGMENT *segment) {
       }
     }
   }
+  (void)bytesRead;
 }
 
 void TDMS_ReadRawData(FILE *fd, TDMS_FILE *tdms, uint32_t n_segment, long filesize) {
@@ -1151,6 +1152,7 @@ void TDMS_ReadRawData(FILE *fd, TDMS_FILE *tdms, uint32_t n_segment, long filesi
       }
     }
   }
+  (void)bytesRead;
 }
 
 void TDMS_GetValue(FILE *fd, void **value, int32_t datatype) {
@@ -1213,4 +1215,5 @@ void TDMS_GetValue(FILE *fd, void **value, int32_t datatype) {
     fprintf(stderr, "tdms2sdds: unknown data type\n");
     exit(EXIT_FAILURE);
   }
+  (void)bytesRead;
 }


### PR DESCRIPTION
## Summary
- capture and silence `system` return values in plotting and server code
- check `chdir` return value in `sddslogserver`
- mark `bytesRead` variables as used in `tdms2sdds`

## Testing
- `make -j2` *(fails: build interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684319d7e16c83258aaaf06be51cd20e