### PR TITLE
Fix inaccurate type lists in SDDS_utils doc comments

### DIFF
--- a/SDDSlib/SDDS_utils.c
+++ b/SDDSlib/SDDS_utils.c
@@ -40,6 +40,8 @@ int lockf(int filedes, int function, off_t size);
  *                     - `SDDS_FLOAT`
  *                     - `SDDS_LONG`
  *                     - `SDDS_ULONG`
+ *                     - `SDDS_LONG64`
+ *                     - `SDDS_ULONG64`
  *                     - `SDDS_SHORT`
  *                     - `SDDS_USHORT`
  *                     - `SDDS_CHARACTER`
@@ -131,6 +133,8 @@ int32_t SDDS_PrintTypedValue(void *data, int64_t index, int32_t type, char *form
  *                     - `SDDS_FLOAT`
  *                     - `SDDS_LONG`
  *                     - `SDDS_ULONG`
+ *                     - `SDDS_LONG64`
+ *                     - `SDDS_ULONG64`
  *                     - `SDDS_SHORT`
  *                     - `SDDS_USHORT`
  *                     - `SDDS_CHARACTER`


### PR DESCRIPTION
## Summary
- correct the list of supported SDDS types in two doxygen comments in `SDDS_utils.c`

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_684329b20bd08325b2b96db7d925bbd5