### PR TITLE
Fix inaccurate Doxygen comments in mdbmth

### DIFF
--- a/mdbmth/bsODEp.c
+++ b/mdbmth/bsODEp.c
@@ -40,7 +40,7 @@ void bs_qctune(double newStepIncreaseFactor, double newStepDecreaseFactor) {
 #define NUSE 7
 
 /* routine: bs_step
- * purpose: perform a quality-control Burlisch-Stoer step
+ * purpose: perform a quality-control Bulirsch-Stoer step
  * Based on Numerical Recipes in C.
  * M. Borland, 1995
  */

--- a/mdbmth/medianfilter.c
+++ b/mdbmth/medianfilter.c
@@ -156,9 +156,9 @@ double quickSelect(double *arr, int n) {
  */
 void median_filter(double *x, double *m, long n, long W) {
   /* x  -- input signal
-     m  -- output signal buffer 
+     m  -- output signal buffer
      n  -- size of input signal
-     W  -- size of slding window (must be odd number) W = 2*W2 + 1) */
+     W  -- size of sliding window (must be odd number) W = 2*W2 + 1) */
   long i, k, idx, W2;
   double *w;
   if (W % 2 == 0)

--- a/mdbmth/mmid.c
+++ b/mdbmth/mmid.c
@@ -3,8 +3,8 @@
  * @brief Modified midpoint method for integrating ordinary differential equations (ODEs).
  *
  * This file implements the modified midpoint method for integrating ODEs,
- * based on the algorithms presented in "Numerical Recipes in C" by
- * Michael Borland (1995).
+ * based on algorithms presented in "Numerical Recipes in C" by
+ * Press et al.
  *
  * @copyright 
  *   - (c) 2002 The University of Chicago, as Operator of Argonne National Laboratory.

--- a/mdbmth/zeroInterp.c
+++ b/mdbmth/zeroInterp.c
@@ -36,7 +36,7 @@
  */
 double zeroInterp(
   double (*fn)(double x), /* pointer to function to be zeroed */
-  double value,   /* sovle for fn=value */
+  double value,   /* solve for fn=value */
   double x_i,     /* initial, final values for independent variable */
   double x_f,
   double dx,    /* size of steps in independent variable */


### PR DESCRIPTION
## Summary
- correct citation in `mmid.c`
- fix misspelling in `bsODEp.c` Doxygen comment
- correct typo in `zeroInterp.c`
- fix comment typo in `medianfilter.c`

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_684329a1ff648325be26d17d24e78db5