### PR TITLE
Fix rpns doxygen comments

### DIFF
--- a/rpns/code/conditional.c
+++ b/rpns/code/conditional.c
@@ -28,7 +28,7 @@
 /* prototypes for this file are in conditional.prot */
 /* file    : conditional.c
  * contents: conditional(), dissect_conditional()
- * purpose : implemetation of conditionals in RPN
+ * purpose : implementation of conditionals in RPN
  *
  * Michael Borland, 1988
  */

--- a/rpns/code/execute.c
+++ b/rpns/code/execute.c
@@ -238,7 +238,7 @@ void quit(void)
   exit(1);
 }
 
-/* routine: help()
+/* routine: rpn_help()
  * purpose: implement user's 'help' command
  */
 

--- a/rpns/code/memory.c
+++ b/rpns/code/memory.c
@@ -43,7 +43,9 @@
 
 /* prototypes for this file are in memory.prot */
 /* file    : memory.c
- * contents: store(), rpn_store(), rpn_create_mem(), is_memory(), revmem(), viewmem(), rpn_recall()
+ * contents: rpn_create_mem(), rpn_store(), rpn_quick_store(), rpn_recall(),
+ *           rpn_str_recall(), store_in_mem(), store_in_str_mem(),
+ *           is_memory(), revmem()
  * purpose : RPN memory routines
  *
  * Michael Borland, 1988, 1992
@@ -155,8 +157,8 @@ char *rpn_str_recall(long memory_number)
 }
 
 
-/* routine: store_in_mem()
- * purpose: implements user's 'sto' command
+/* routine: store_in_str_mem()
+ * purpose: implements user's 'ssto' command
  */
 
 void store_in_mem(void)
@@ -184,8 +186,8 @@ void store_in_mem(void)
     memoryData[i_mem] = stack[stackptr-1];
 }
 
-/* routine: store_in_mem()
- * purpose: implements user's 'sto' command
+/* routine: store_in_str_mem()
+ * purpose: implements user's 'ssto' command
  */
 
 void store_in_str_mem(void)
@@ -214,7 +216,7 @@ void store_in_str_mem(void)
 }
 
 /* routine: is_memory()
- * purpose: return the memory numberof a named memory, and put the
+ * purpose: return the memory number of a named memory, and put the
  *          data stored in the memory into a location supplied by the
  *          caller.  Basically an implementation of the memory recall
  *          facility.

--- a/rpns/code/pop_push.c
+++ b/rpns/code/pop_push.c
@@ -31,7 +31,7 @@
  *           pop_string(), push_string()
  *           push_code(), pop_code()
  *
- * purpose : stack maintainence subroutines for RPN
+ * purpose : stack maintenance subroutines for RPN
  * Michael Borland, 1988
  */
 #include "rpn_internal.h"

--- a/rpns/code/rpn_csh.c
+++ b/rpns/code/rpn_csh.c
@@ -49,8 +49,8 @@
  *
 */
 
-/* file: rpn_csh.
- * purpose: create and manage a synchronize csh subprocess
+/* file: rpn_csh.c
+ * purpose: create and manage a synchronized csh subprocess
  *
  * M. Borland, 1993
  */

--- a/rpns/code/rpn_error.c
+++ b/rpns/code/rpn_error.c
@@ -19,7 +19,7 @@
 */
 
 /* file: rpn_error.c
- * purpose: record occurence of errors in rpn routines
+ * purpose: record occurrence of errors in rpn routines
  *
  * Michael Borland, 1994.
  */

--- a/rpns/code/rpn_io.c
+++ b/rpns/code/rpn_io.c
@@ -31,7 +31,7 @@
 /* file    : rpn_io.c
  * contents: open_cominp(), open_io(), close_io()
  *           choose_format(), view(), view_top(), tsci(), viewlog(), fprf()
- *           scan(), _gets(), _puts()
+ *           scan(), rpn_gets(), rpn_puts()
  * purpose : user-callable IO routines
  *
  * Michael Borland, 1988
@@ -180,7 +180,7 @@ void close_io(void)
     io_file[unit].mode = -1;
     }
 
-/* routine: _gets()
+/* routine: rpn_gets()
  * purpose: implement the user command 'gets'
  */
 
@@ -366,7 +366,7 @@ void view_str(void)
             sstack[i]);
     }
 
-/* routine: _puts()
+/* routine: rpn_puts()
  * purpose: implement 'puts' command
  */
 


### PR DESCRIPTION
## Summary
- correct outdated or inaccurate doxygen comments in rpns
- fix typos in documentation text

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_68436be7227c83259eeb9fb45ed4dc51