### PR TITLE
Fix missing toolkit doc references

### DIFF
--- a/SDDSaps/doc/SDDStoolkit.tex
+++ b/SDDSaps/doc/SDDStoolkit.tex
@@ -1170,9 +1170,14 @@ only the x values, since these are more interesting:
 \input{elegant2genesis.tex}
 \input{hpif2sdds.tex}
 \input{hdf2sdds.tex}
+\input{image2sdds.tex}
 \input{lba2sdds.tex}
 \input{plaindata2sdds.tex}
 \input{raw2sdds.tex}
+\input{sdds2dfft.tex}
+\input{sdds2dinterpolate.tex}
+\input{sdds2headlessdata.tex}
+\input{sdds2tiff.tex}
 \input{sdds2dpfit.tex}
 \input{sdds2math.tex}
 \input{sdds2plaindata.tex}
@@ -1263,6 +1268,8 @@ only the x values, since these are more interesting:
 \input{sddsxref.tex}
 \input{sddszerofind.tex}
 \input{sddsEditing.tex}
+\input{sddsanalyticssignal.tex}
+\input{sddsarray2column.tex}
 \input{rpn.tex}
 \input{sddswildcards.tex}
 


### PR DESCRIPTION
## Summary
- add several missing program manuals to `SDDStoolkit.tex`

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_68444435ed408325b56c6f666881a761