### PR TITLE
Add collapsible panels in sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -18,6 +18,9 @@
 #include <QLineEdit>
 #include <QStandardItemModel>
 
+class QGroupBox;
+class QSplitter;
+
 struct ArrayStore {
   QVector<QString> values;
   QVector<int> dims;
@@ -72,6 +75,10 @@ private:
   QTableView *paramView;
   QTableView *columnView;
   QTableView *arrayView;
+  QGroupBox *paramBox;
+  QGroupBox *colBox;
+  QGroupBox *arrayBox;
+  QSplitter *dataSplitter;
   QStandardItemModel *paramModel;
   QStandardItemModel *columnModel;
   QStandardItemModel *arrayModel;


### PR DESCRIPTION
## Summary
- make parameter, column and array panels collapsible
- place panels inside a `QSplitter` so users can resize them
- hide empty panels by default when loading a file

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_684602eec400832590f101f519510e25