### PR TITLE
Add copy/paste support to sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -49,6 +49,8 @@ private slots:
   void saveFile();
   void search();
   void pageChanged(int value);
+  void copy();
+  void paste();
 
 private:
   void loadPage(int page);
@@ -60,6 +62,7 @@ private:
   void changeArrayType(int column);
   void message(const QString &text);
   void markDirty();
+  QTableView *focusedTable() const;
 
   SDDS_DATASET dataset;
   bool datasetLoaded;


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for copy and paste
- implement copy/paste helpers for tables

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_68461bcf057883259dcb083a9bb77324