### PR TITLE
Ensure black text in sddseditor

### DIFF
--- a/SDDSaps/sddseditor/main.cc
+++ b/SDDSaps/sddseditor/main.cc
@@ -5,9 +5,16 @@
 
 #include "SDDSEditor.h"
 #include <QApplication>
+#include <QPalette>
 
 int main(int argc, char **argv) {
   QApplication app(argc, argv);
+  QPalette pal = app.palette();
+  pal.setColor(QPalette::Active, QPalette::Text, Qt::black);
+  pal.setColor(QPalette::Inactive, QPalette::Text, Qt::black);
+  pal.setColor(QPalette::Active, QPalette::WindowText, Qt::black);
+  pal.setColor(QPalette::Inactive, QPalette::WindowText, Qt::black);
+  app.setPalette(pal);
   SDDSEditor editor;
   if (argc > 1)
     editor.loadFile(argv[1]);


### PR DESCRIPTION
## Summary
- guarantee SDDS editor widgets always display black text

## Testing
- `make clean`
- `make -j`


------
https://chatgpt.com/codex/tasks/task_e_68461bc5a3bc8325b81e249bf089e8d9