### PR TITLE
Fix typos in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd ..
 ├── xlslib/         # xlslib (Excel) library used by sdds2spreadsheet
 ├── zlib/           # GZip support for Windows
 ├── lzma/           # LZMA support for Windows
-├── mdblib/         # memory managment and utility functions
+├── mdblib/         # memory management and utility functions
 ├── mdbmth/         # mathematical computations and numerical analysis functions
 ├── rpns/code       # RPN (Reverse Polish Notation) libraries
 ├── namelist/       # namelist pre-processor for C programs

--- a/SDDSaps/doc/hdf2sdds.tex
+++ b/SDDSaps/doc/hdf2sdds.tex
@@ -14,7 +14,7 @@ hdf2sdds data.hdf data.sdds -withIndex
 \item {\bf synopsis:}
 \begin{flushleft}{\tt
 hdf2sdds [{\em HDFfile}] [{\em SDDSfile}] [-pipe[=out]]
-[-query] [-ascii] [-binary] [-withIndex] [-reduceFactor={\em integer}[,keep={\em interger}]] [-3doutput]
+[-query] [-ascii] [-binary] [-withIndex] [-reduceFactor={\em integer}[,keep={\em integer}]] [-3doutput]
 }\end{flushleft}
 \item {\bf files: }
 
@@ -29,7 +29,7 @@ hdf2sdds [{\em HDFfile}] [{\em SDDSfile}] [-pipe[=out]]
     \item {\tt -ascii} --- Requests that the output be ASCII.
     \item {\tt -binary} --- Requests that the output be binary.
     \item {\tt -withIndex} --- An index column is added to the output file.
-    \item {\tt -reduceFactor={\em integer}[,keep={\em interger}]} --- Write the first {\em keep}th value of every {\em reduceFactor} values in order to reduce the size of ouput file. The attributes are written to the output file by their originial data types.
+    \item {\tt -reduceFactor={\em integer}[,keep={\em integer}]} --- Write the first {\em keep}th value of every {\em reduceFactor} values in order to reduce the size of output file. The attributes are written to the output file by their original data types.
     \item {\tt -3doutput} --- Used to convert 3-dimensional HDF data.
 \end{itemize}
 \item {\bf author:} R. Soliday, ANL/APS.

--- a/SDDSaps/doc/sddsEditing.tex
+++ b/SDDSaps/doc/sddsEditing.tex
@@ -32,15 +32,15 @@ The commands are as follows:
         search string. {\em -delim-} may be any nonspace character except a question mark.
 \item [] [{\em n}]s?{\em -delim-}{\em text}{\em -delim-} --- Search for {\em text},  delimited
          by the character {\em -delim-} 1 or {\em n} times.   Abort all subsequent editing
-        if the search fails.  If the search suceeds, leave the position at the end of the
+         if the search fails.  If the search succeeds, leave the position at the end of the
         search string. {\em -delim-} may be any nonspace character except a question mark.
 \item [] S?{\em -delim-}{\em text}{\em -delim-} --- Search for {\em text},  delimited
          by the character {\em -delim-}.   Abort all subsequent editing
-        if the search fails.  If the search suceeds, leave the position at the start of the
+         if the search fails.  If the search succeeds, leave the position at the start of the
         search string. {\em -delim-} may be any nonspace character except a question mark.
 \item [] [{\em n}]k --- Delete forward from the present position 1 or {\em n} characters, placing them in the kill buffer.
 \item [] [{\em n}]K --- Delete forward from the present position 1 or {\em n} words, placing them in the kill buffer.
-\item [] z{\em char} --- Delete forward from the present position up to the first occurence of the character {\em char},
+\item [] z{\em char} --- Delete forward from the present position up to the first occurrence of the character {\em char},
         placing the deleted text in the kill buffer.
 \item [] [{\em n}]Z{\em char} --- Delete 1 or {\em n} times up to and including the
         character {\em char}, placing the deleted text in the kill buffer.
@@ -48,7 +48,7 @@ The commands are as follows:
 \item [] [{\em n}]\%{\em -delim-}{\em text1}{\em -delim-}{\em text2}{\em -delim-} ---
         Replace {\em text1} with {\em text2} 1 or {\em n} times starting at the
         present position.  {\em -delim-} may be any nonspace character.  For example,
-        ``10\%/c/C/'' would capitalize the next 10 occurences of the character 'c'.
+         ``10\%/c/C/'' would capitalize the next 10 occurrences of the character 'c'.
 \item {\bf see also:}
     \begin{itemize}
     \item \progref{sddsprocess}


### PR DESCRIPTION
## Summary
- fix spelling mistake in README
- correct typos in hdf2sdds.tex
- correct typos in sddsEditing.tex

## Testing
- `codespell README.md SDDSaps/doc/hdf2sdds.tex SDDSaps/doc/sddsEditing.tex`

------
https://chatgpt.com/codex/tasks/task_e_6846eb70c4048324ad4cc60e42f5996d