### PR TITLE
Add safe layout refresh after removing items

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -57,6 +57,9 @@ private slots:
   void editParameterAttributes();
   void editColumnAttributes();
   void editArrayAttributes();
+  void deleteParameter();
+  void deleteColumn();
+  void deleteArray();
 
 private:
   void loadPage(int page);


### PR DESCRIPTION
## Summary
- simplify helper functions for deleting SDDS items
- update original layout via `SDDS_SaveLayout` after removing parameters, columns or arrays

## Testing
- `make clean`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68470de163748325bc3b8f9ce776463e