### PR TITLE
Enable inserting parameters, columns and arrays in SDDSeditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -57,6 +57,9 @@ private slots:
   void editParameterAttributes();
   void editColumnAttributes();
   void editArrayAttributes();
+  void insertParameter();
+  void insertColumn();
+  void insertArray();
   void deleteParameter();
   void deleteColumn();
   void deleteArray();


### PR DESCRIPTION
## Summary
- implement Insert actions for parameters, columns and arrays
- create dialog windows mirroring the attribute editor when inserting
- update menu wiring

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_684730a84d688325bbdc709168bdd802