### PR TITLE
Enable table cell context menus in sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -66,7 +66,9 @@ private slots:
   void insertColumnRows();
   void deleteColumnRows();
   void columnHeaderMenuRequested(const QPoint &pos);
+  void columnCellMenuRequested(const QPoint &pos);
   void arrayHeaderMenuRequested(const QPoint &pos);
+  void arrayCellMenuRequested(const QPoint &pos);
   void plotColumn(int column);
 
 private:
@@ -78,6 +80,8 @@ private:
   void changeParameterType(int row);
   void changeColumnType(int column);
   void changeArrayType(int column);
+  void showColumnMenu(QTableView *view, int column, const QPoint &globalPos);
+  void showArrayMenu(QTableView *view, int column, const QPoint &globalPos);
   void sortColumn(int column, Qt::SortOrder order);
   void searchColumn(int column);
   void searchArray(int column);


### PR DESCRIPTION
## Summary
- allow column/array menus from table cells
- wire up slots to show context menus on right-click
- move helper functions into class

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_6848806e33b08325a390bd20cc116329