### PR TITLE
Add page editing actions

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -65,6 +65,9 @@ private slots:
   void deleteArray();
   void insertColumnRows();
   void deleteColumnRows();
+  void clonePage();
+  void insertPage();
+  void deletePage();
   void columnHeaderMenuRequested(const QPoint &pos);
   void columnCellMenuRequested(const QPoint &pos);
   void arrayHeaderMenuRequested(const QPoint &pos);


### PR DESCRIPTION
## Summary
- allow cloning, inserting, and deleting pages in the SDDS editor
- hook up `pageMenu` actions to new slots
- fix deleting wrong page when removing pages

## Testing
- `make clean`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68488e70632c832594c24db43a4ed7cd