### PR TITLE
Enable drag reordering in sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -75,6 +75,9 @@ private slots:
   void plotColumn(int column);
   void restartApp();
   void showHelp();
+  void parameterMoved(int logical, int oldVisual, int newVisual);
+  void columnMoved(int logical, int oldVisual, int newVisual);
+  void arrayMoved(int logical, int oldVisual, int newVisual);
 
 private:
   void loadPage(int page);


### PR DESCRIPTION
## Summary
- allow parameters, columns and arrays to be reordered by dragging table headers
- update SDDS editor UI connections to handle section moved events

## Testing
- `make clean`
- `make -j`


------
https://chatgpt.com/codex/tasks/task_e_6848b33c0cb08325a73530f11be147a2