### PR TITLE
Add undo/redo to sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -20,6 +20,7 @@
 #include <QVector>
 #include <QString>
 #include <QPoint>
+#include <QUndoStack>
 
 class QGroupBox;
 class QSplitter;
@@ -54,6 +55,8 @@ private slots:
   void pageChanged(int value);
   void copy();
   void paste();
+  void undo();
+  void redo();
   void editParameterAttributes();
   void editColumnAttributes();
   void editArrayAttributes();
@@ -116,6 +119,8 @@ private:
   QStandardItemModel *paramModel;
   QStandardItemModel *columnModel;
   QStandardItemModel *arrayModel;
+
+  QUndoStack *undoStack;
 
   QVector<PageStore> pages;
   int currentPage;


### PR DESCRIPTION
## Summary
- add undo support to cell edits and paste operations
- expose Undo/Redo menu actions
- fix member initialization order warning

## Testing
- `make clean`
- `make -j`


------
https://chatgpt.com/codex/tasks/task_e_6848b49f11848325b74a9dae0a33440a