### PR TITLE
Add undo/redo to SDDS editor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -20,6 +20,7 @@
 #include <QVector>
 #include <QString>
 #include <QPoint>
+#include <QUndoStack>
 
 class QGroupBox;
 class QSplitter;
@@ -128,6 +129,7 @@ private:
   int lastRowAddCount;
   QString lastSearchPattern;
   QString lastReplaceText;
+  QUndoStack *undoStack;
 };
 
 #endif // SDDSEDITOR_H


### PR DESCRIPTION
## Summary
- add `QUndoStack` to `SDDSEditor`
- implement `SetDataCommand` and update `SDDSItemDelegate` to push undo commands
- hook undo/redo actions to the Edit menu

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_6848d86d18408325ad6a802b5caef3b8