### PR TITLE
Enable multi-cell delete in sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.cc
+++ b/SDDSaps/sddseditor/SDDSEditor.cc
@@ -325,6 +325,8 @@ SDDSEditor::SDDSEditor(QWidget *parent)
   connect(copySc, &QShortcut::activated, this, &SDDSEditor::copy);
   QShortcut *pasteSc = new QShortcut(QKeySequence::Paste, this);
   connect(pasteSc, &QShortcut::activated, this, &SDDSEditor::paste);
+  QShortcut *delSc = new QShortcut(QKeySequence::Delete, this);
+  connect(delSc, &QShortcut::activated, this, &SDDSEditor::deleteCells);
 
   setCentralWidget(central);
   resize(1200, 800);
@@ -636,6 +638,20 @@ void SDDSEditor::paste() {
   }
   if (changed)
     markDirty();
+}
+
+void SDDSEditor::deleteCells() {
+  QTableView *view = focusedTable();
+  if (!view)
+    return;
+  QModelIndexList indexes = view->selectionModel()->selectedIndexes();
+  if (indexes.isEmpty())
+    return;
+  for (const QModelIndex &idx : indexes) {
+    if (idx.isValid())
+      view->model()->setData(idx, QString());
+  }
+  markDirty();
 }
 
 void SDDSEditor::openFile() {

--- a/SDDSaps/sddseditor/SDDSEditor.h
+++ b/SDDSaps/sddseditor/SDDSEditor.h
@@ -57,6 +57,7 @@ private slots:
   void pageChanged(int value);
   void copy();
   void paste();
+  void deleteCells();
   void editParameterAttributes();
   void editColumnAttributes();
   void editArrayAttributes();


### PR DESCRIPTION
## Summary
- handle Delete key in the sddseditor
- clear all selected cells when Delete is pressed

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_6849d2a473ac8325a54a76a68fb14aa3