### PR TITLE
Improve numeric column sorting in sddseditor

### DIFF
--- a/SDDSaps/sddseditor/SDDSEditor.cc
+++ b/SDDSaps/sddseditor/SDDSEditor.cc
@@ -4,6 +4,7 @@
  */
 
 #include "SDDSEditor.h"
+#include "mdb.h"
 
 #include <QMenuBar>
 #include <QFileDialog>
@@ -1842,6 +1843,11 @@ void SDDSEditor::sortColumn(int column, Qt::SortOrder order) {
       long double aval = av.toDouble();
       long double bval = bv.toDouble();
       return order == Qt::AscendingOrder ? aval < bval : aval > bval;
+    } else if (type == SDDS_STRING) {
+      QByteArray aa = av.toUtf8();
+      QByteArray bb = bv.toUtf8();
+      int r = strcmp_nh(aa.constData(), bb.constData());
+      return order == Qt::AscendingOrder ? r < 0 : r > 0;
     }
     return order == Qt::AscendingOrder ? av < bv : av > bv;
   };


### PR DESCRIPTION
## Summary
- include `mdb.h` in the Qt editor
- sort string columns using the same numeric-aware comparison as `sddssort -numeric`

## Testing
- `make clean`
- `make -j`

------
https://chatgpt.com/codex/tasks/task_e_6849d26dd7a88325a0f15816a15e357b