### PR TITLE
Add documentation scaffold for SDDS library

### DIFF
--- a/SDDSlib/doc/AGENTS.md
+++ b/SDDSlib/doc/AGENTS.md
@@ -1,0 +1,10 @@
+# Documentation Style Guide
+
+This directory contains Markdown files for the SDDS library.
+
+- Use Markdown with fenced code blocks for commands and paths.
+- Indent using two spaces; avoid tabs.
+- Wrap lines at a reasonable length (~100 characters).
+- Reference source files and directories with relative paths.
+
+

--- a/SDDSlib/doc/README.md
+++ b/SDDSlib/doc/README.md
@@ -1,0 +1,24 @@
+# SDDS Library Documentation
+
+This directory contains documentation for the core SDDS C/C++ library.
+
+## Building
+
+From the repository root or within `SDDSlib`:
+
+```bash
+make -j
+```
+
+The build generates the static library at `lib/<OS>-<ARCH>/libSDDS1.a`.
+
+## Usage
+
+Include headers from the `include/` directory and link against `libSDDS1.a`.
+See the sample programs in `SDDSlib/demo` for basic reading and writing
+examples.
+
+Source files contain Doxygen-style comments that can be processed with tools
+like `doxygen` to produce API references. Additional documents can be added
+here to expand the library documentation.
+


### PR DESCRIPTION
## Summary
- Documented SDDS library structure and build instructions
- Introduced Markdown style guide for future library docs

## Testing
- `make clean -C SDDSlib`
- `make -j2 -C SDDSlib`


------
https://chatgpt.com/codex/tasks/task_e_689a240f733883259f86a1b059e35fbf