### PR TITLE
doc: improve time utility Doxygen docs

### DIFF
--- a/mdblib/time.c
+++ b/mdblib/time.c
@@ -24,16 +24,20 @@ static char *month[12] = {
   "august", "september", "october",
   "november", "december"};
 
-/* routine: convert_date_time()
- * purpose: convert time string, as from mtime(), to DATE_TIME structure.
- * assumed format of input string: day month year hours:minutes
- * The month must be written out (e.g., "June", not 6).
- * Michael Borland, 1987
+/**
+ * @brief Converts a time string into a DATE_TIME structure.
+ *
+ * The input should have the format "day month year hours:minutes" with the
+ * month written out (e.g., "June" rather than "6").
+ *
+ * @param dt Pointer to the DATE_TIME structure to populate.
+ * @param ct0 String containing the time specification.
+ * @return 1 on success, 0 on failure, or NO_TIME if the format is invalid.
  */
 
 convert_date_time(dt, ct0)
   DATE_TIME *dt;
-char *ct0;
+  char *ct0;
 {
   register char *ptr, *ct;
   register long i, l;

--- a/mdblib/timeconvert.c
+++ b/mdblib/timeconvert.c
@@ -16,6 +16,14 @@
 #include "mdb.h"
 #include <time.h>
 
+/**
+ * @brief Determines whether a given year is a leap year.
+ *
+ * Years below 100 are interpreted as 19xx if greater than 95, otherwise 20xx.
+ *
+ * @param year The year to evaluate.
+ * @return 1 if the year is a leap year, 0 if not, and -1 for invalid input.
+ */
 short IsLeapYear(short year) {
   if (year < 0)
     return -1;
@@ -57,6 +65,15 @@ static short DaysInMonths[2][12] = {
   },
 };
 
+/**
+ * @brief Computes the Julian day number from a calendar date.
+ *
+ * @param month Month of the year (1-12).
+ * @param day Day of the month.
+ * @param year Year value.
+ * @param julianDay Pointer to store the resulting Julian day number.
+ * @return 1 on success, 0 on failure.
+ */
 short JulianDayFromMonthDay(short month, short day, short year, short *julianDay) {
   short leapYear, jday, i, daysInMonth;
 
@@ -75,6 +92,15 @@ short JulianDayFromMonthDay(short month, short day, short year, short *julianDay
   return 1;
 }
 
+/**
+ * @brief Converts a Julian day number to month and day components.
+ *
+ * @param julianDay The Julian day number to convert.
+ * @param year Year corresponding to the Julian day.
+ * @param month Pointer to store the resulting month (1-12).
+ * @param day Pointer to store the resulting day of the month.
+ * @return 1 on success, 0 on failure.
+ */
 short MonthDayFromJulianDay(short julianDay, short year, short *month, short *day) {
   short leapYear, sum, i, days;
 


### PR DESCRIPTION
## Summary
- add Doxygen block for VAX VMS `convert_date_time`
- document leap-year and Julian day helpers in `timeconvert.c`

## Testing
- `make mdblib`


------
https://chatgpt.com/codex/tasks/task_e_689a2456ff148325a6b75c4821aedd86