### PR TITLE
Improve Doxygen docs in SDDSlib

### DIFF
--- a/SDDSlib/SDDS_binary.c
+++ b/SDDSlib/SDDS_binary.c
@@ -43,8 +43,14 @@ double makeFloat64FromFloat80(unsigned char x[16], int32_t byteOrder);
 
 static int32_t defaultIOBufferSize = SDDS_FILEBUFFER_SIZE;
 
-/* this routine is obsolete.  Use SDDS_SetDefaultIOBufferSize(0) to effectively turn
- * off buffering.
+/**
+ * @brief Obsolete routine retained for backward compatibility.
+ *
+ * This function no longer performs any operations. Use
+ * SDDS_SetDefaultIOBufferSize(0) to disable buffering instead.
+ *
+ * @param dummy Unused parameter kept for API compatibility.
+ * @return Always returns 0.
  */
 int32_t SDDS_SetBufferedRead(int32_t dummy) {
   return 0;

--- a/SDDSlib/SDDS_dataprep.c
+++ b/SDDSlib/SDDS_dataprep.c
@@ -1,18 +1,24 @@
 /**
  * @file SDDS_dataprep.c
- * @brief This file provides functions for SDDS dataset preparations.
+ * @brief Functions for preparing SDDS data sets
  *
- * This file provides functions for SDDS dataset preparations.
+ * @details Implements utility routines used prior to writing or
+ * manipulating SDDS tables, such as allocating column flags and starting
+ * new pages.
  *
- * @copyright 
+ * @copyright
  *   - (c) 2002 The University of Chicago, as Operator of Argonne National Laboratory.
  *   - (c) 2002 The Regents of the University of California, as Operator of Los Alamos National Laboratory.
  *
- * @license 
+ * @license
  * This file is distributed under the terms of the Software License Agreement
  * found in the file LICENSE included with this distribution.
  *
- * @author M. Borland, C. Saunders, R. Soliday. H. Shang
+ * @authors
+ *   M. Borland,
+ *   C. Saunders,
+ *   R. Soliday,
+ *   H. Shang
  */
 
 #include "SDDS.h"

--- a/SDDSlib/SDDS_utils.c
+++ b/SDDSlib/SDDS_utils.c
@@ -1,18 +1,23 @@
 /**
  * @file SDDS_utils.c
- * @brief This file provides miscellaneous functions for interacting with SDDS objects.
+ * @brief Miscellaneous helper functions for SDDS objects
  *
- * This file provides miscellaneous functions for interacting with SDDS objects.
+ * @details Provides general-purpose routines for working with SDDS data
+ * sets, including value printing and data buffer management.
  *
- * @copyright 
+ * @copyright
  *   - (c) 2002 The University of Chicago, as Operator of Argonne National Laboratory.
  *   - (c) 2002 The Regents of the University of California, as Operator of Los Alamos National Laboratory.
  *
- * @license 
+ * @license
  * This file is distributed under the terms of the Software License Agreement
  * found in the file LICENSE included with this distribution.
  *
- * @author M. Borland, C. Saunders, R. Soliday. H. Shang
+ * @authors
+ *   M. Borland,
+ *   C. Saunders,
+ *   R. Soliday,
+ *   H. Shang
  */
 
 #include "SDDS.h"


### PR DESCRIPTION
## Summary
- Clarified obsolete buffering function documentation in SDDS_binary
- Refined SDDS_dataprep description of data preparation utilities
- Expanded SDDS_utils header to better describe helper routines

## Testing
- `make clean`
- `make -j`


------
https://chatgpt.com/codex/tasks/task_e_689a247453ec8325860c7d02d1b304a4